### PR TITLE
Restrict multiple moves and attacks per piece. Auto commit if not attacks available that turn

### DIFF
--- a/src/gameMechanics/Board/Board.ts
+++ b/src/gameMechanics/Board/Board.ts
@@ -208,7 +208,6 @@ export class Board<PR extends PieceRegistry> implements IBoard<PR> {
       this.piecesState.layoutMatrix,
       moves.reduce(
         (prev, next, i) => {
-          console.log('next move ==>', next);
           const piece = pieces[i];
           piece.state.pieceHasMoved = true;
           const castle = next.castle
@@ -230,7 +229,6 @@ export class Board<PR extends PieceRegistry> implements IBoard<PR> {
                 }
               ]
             : [];
-          console.log('castle in board', castle);
           return [
             ...prev,
             {

--- a/src/gameMechanics/Board/Board.ts
+++ b/src/gameMechanics/Board/Board.ts
@@ -208,8 +208,29 @@ export class Board<PR extends PieceRegistry> implements IBoard<PR> {
       this.piecesState.layoutMatrix,
       moves.reduce(
         (prev, next, i) => {
+          console.log('next move ==>', next);
           const piece = pieces[i];
-
+          piece.state.pieceHasMoved = true;
+          const castle = next.castle
+            ? [
+                {
+                  index: [
+                    next.castle.from.row,
+                    next.castle.from.col
+                  ] as MatrixIndex,
+                  nextVal: 0 as 0
+                },
+                {
+                  index: [
+                    next.castle.to.row,
+                    next.castle.to.col
+                  ] as MatrixIndex,
+                  nextVal: this.getPieceByCoord(next.castle.from)!.state
+                    .id as string
+                }
+              ]
+            : [];
+          console.log('castle in board', castle);
           return [
             ...prev,
             {
@@ -219,7 +240,8 @@ export class Board<PR extends PieceRegistry> implements IBoard<PR> {
             {
               index: [next.to.row, next.to.col],
               nextVal: piece.state.id
-            }
+            },
+            ...castle
           ];
         },
         [] as {

--- a/src/gameMechanics/Game/Game.ts
+++ b/src/gameMechanics/Game/Game.ts
@@ -395,16 +395,9 @@ export class Game<PR extends PieceRegistry = PieceRegistry> implements IGame {
       return new Err(getAttackNotPossibleError('DestinationNotValid'));
     }
 
-    console.log(
-      'this color attacks : ',
-      (this.state as GameStateInAttackPhase)[piece.state.color].attacks
-    );
-
     const indexOfAPreviousAttackByPiece = (
       (this.state as GameStateInAttackPhase)[piece.state.color].attacks || []
     ).findIndex((a) => coordsAreEqual(a.from, from));
-
-    console.log('index of prev attack', indexOfAPreviousAttackByPiece);
 
     if (indexOfAPreviousAttackByPiece !== -1) {
       this.partialState = {
@@ -417,7 +410,6 @@ export class Game<PR extends PieceRegistry = PieceRegistry> implements IGame {
           ).slice(0, indexOfAPreviousAttackByPiece)
         }
       };
-      console.log('new state ', this.partialState);
     }
 
     const preparingState: GameStateInAttackPhaseWithPreparingSubmission = {

--- a/src/gameMechanics/Game/Game.ts
+++ b/src/gameMechanics/Game/Game.ts
@@ -18,7 +18,7 @@ import {
   getAttackNotPossibleError
 } from './errors/helpers';
 import { Board } from '../Board/Board';
-import { coordsAreEqual } from '../util';
+import { coordsAreEqual, matrixForEach } from '../util';
 import { AttackNotPossibleError, MoveNotPossibleError } from './errors';
 import {
   isGameInAttackPhase,
@@ -27,7 +27,7 @@ import {
   isGameInMovePhaseWithPreparingSubmission
 } from './helpers';
 import { IGame } from './IGame';
-import { Attack, GameHistory, Move } from '../commonTypes';
+import { Attack, Color, GameHistory, Move } from '../commonTypes';
 import { PieceRegistry } from '../Piece/types';
 
 type GameProps = {
@@ -466,6 +466,22 @@ export class Game<PR extends PieceRegistry = PieceRegistry> implements IGame {
       attack,
       gameState: this.state
     });
+  }
+
+  evalIfPossibleAttacks(color: Color): boolean {
+    return this.state.boardState.pieceLayoutState.some((row, rowIndex) =>
+      row.some((col, colIndex) => {
+        const piece = this.board.getPieceByCoord({
+          row: rowIndex,
+          col: colIndex
+        });
+        if (!piece || piece.state.color !== color) {
+          return false;
+        }
+
+        return piece.evalAttack(this).length > 0;
+      })
+    );
   }
 
   get state(): GameState {

--- a/src/gameMechanics/Game/IGame.ts
+++ b/src/gameMechanics/Game/IGame.ts
@@ -15,10 +15,7 @@ export interface IGame<PR extends PieceRegistry = PieceRegistry> {
   load(state: GameState): void;
 
   // When a Move is Succesfully Drawn it gets appended to the nextMoves List of the "move" phase
-  drawMove(
-    from: Coord,
-    to: Coord
-  ): Result<
+  drawMove(move: Move): Result<
     {
       move: Move;
       gameState: GameState;

--- a/src/gameMechanics/commonTypes.ts
+++ b/src/gameMechanics/commonTypes.ts
@@ -19,6 +19,7 @@ export type ShortMove = {
   from: Coord;
   to: Coord;
   promotion?: PieceState<string>['label'];
+  castle?: ShortMove; // Rook Move
 };
 
 // TODO: Rename this MoveOutcome so it uses the same standard as Attack
@@ -36,9 +37,10 @@ export type ShortAttack = {
 
 // TODO: This is actuall just the ShortAttack as the SpecialAttacks aren't needed here!
 // TODO: Take the SpecialAttacks out as they aren't needed in the Attack
-export type Attack = ShortAttack & SpecialAttacks & {
-  type: 'range' | 'melee';
-};
+export type Attack = ShortAttack &
+  SpecialAttacks & {
+    type: 'range' | 'melee';
+  };
 
 export type SpecialAttacks = {
   // heal?: boolean;

--- a/src/mahaDosGame/Pieces/Bishop/Bishop.ts
+++ b/src/mahaDosGame/Pieces/Bishop/Bishop.ts
@@ -120,15 +120,14 @@ export class Bishop extends Piece {
         if (r === 1) {
           if (
             targetPiece.state.label === 'Rook' ||
-            targetPiece.state.color === this.state.color
+            (targetPiece.state.color === this.state.color &&
+              targetPiece.state.hitPoints < targetPiece.state.maxHitPoints)
           ) {
             attacks.push({
               from: pieceCoord,
               to: target,
               type: 'range'
             });
-            hitObstacle = true;
-            return;
           }
         } else {
           if (targetPiece.state.color !== this.state.color) {
@@ -138,7 +137,10 @@ export class Bishop extends Piece {
               type: 'range'
             });
           } else {
-            if (r < 4) {
+            if (
+              r < 4 &&
+              targetPiece.state.hitPoints < targetPiece.state.maxHitPoints
+            ) {
               attacks.push({
                 from: pieceCoord,
                 to: target,
@@ -146,9 +148,9 @@ export class Bishop extends Piece {
               });
             }
           }
-          hitObstacle = true;
-          return;
         }
+        hitObstacle = true;
+        return;
       });
     });
 
@@ -186,11 +188,11 @@ export class Bishop extends Piece {
           : 0;
     }
 
-    //TODO - heal can only go to max hit points of the target piece
     const damage = heal
-      ? Math.ceil(targetPiece.state.hitPoints / 2) > 5
-        ? -5
-        : -Math.ceil(targetPiece.state.hitPoints / 2)
+      ? this.determineHealAmount(
+          targetPiece.state.hitPoints,
+          targetPiece.state.maxHitPoints
+        )
       : this.state.attackDamage - kingDefense + attackBonus;
 
     return Ok({
@@ -201,5 +203,10 @@ export class Bishop extends Piece {
           : true,
       damage
     });
+  }
+
+  private determineHealAmount(hP: number, maxHP: number) {
+    const healAmount = Math.ceil(hP / 2) > 5 ? 5 : Math.ceil(hP / 2);
+    return hP + healAmount <= maxHP ? healAmount : maxHP - hP;
   }
 }

--- a/src/mahaDosGame/Pieces/Bishop/Bishop.ts
+++ b/src/mahaDosGame/Pieces/Bishop/Bishop.ts
@@ -119,7 +119,8 @@ export class Bishop extends Piece {
 
         if (r === 1) {
           if (
-            targetPiece.state.label === 'Rook' ||
+            (targetPiece.state.label === 'Rook' &&
+              targetPiece.state.color !== this.state.color) ||
             (targetPiece.state.color === this.state.color &&
               targetPiece.state.hitPoints < targetPiece.state.maxHitPoints)
           ) {

--- a/src/mahaDosGame/Pieces/King/King.test.ts
+++ b/src/mahaDosGame/Pieces/King/King.test.ts
@@ -82,6 +82,137 @@ describe('eval moves', () => {
 
     expect(moves).toEqual(expectedMoves);
   });
+
+  test('test moves for King with castling options', () => {
+    const configuration: GameConfigurator<typeof mahaPieceRegistry> = {
+      terrain: { width: 8 },
+      pieceLayout: [
+        ['wR', 'wN', 0, 'wK', 0, 0, 'wR', 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        ['bR', 0, 0, 'bK', 0, 0, 0, 'bR']
+      ]
+    };
+    const game = new MahaGame(configuration);
+
+    const whitePiece = game.board.getPieceByCoord({ row: 0, col: 3 });
+    const blackPiece = game.board.getPieceByCoord({ row: 7, col: 3 });
+
+    expect(whitePiece).toBeDefined();
+    expect(blackPiece).toBeDefined();
+
+    if (!whitePiece || !blackPiece) {
+      return;
+    }
+
+    const { state } = game;
+    game.load({
+      ...state,
+      state: 'inProgress',
+      history: [],
+      phase: 'move',
+      white: {
+        canDraw: true,
+        moves: []
+      },
+      black: {
+        canDraw: true,
+        moves: []
+      }
+    } as GameStateInMovePhase);
+
+    const whiteMoves = whitePiece.evalMove(game);
+    const blackMoves = blackPiece.evalMove(game);
+
+    const expectedBlackMoves: Move[] = [
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 6, col: 3 },
+        piece: blackPiece.state
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 6, col: 4 },
+        piece: blackPiece.state
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 7, col: 4 },
+        piece: blackPiece.state
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 7, col: 2 },
+        piece: blackPiece.state
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 6, col: 2 },
+        piece: blackPiece.state
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 7, col: 5 },
+        piece: blackPiece.state,
+        castle: {
+          from: { row: 7, col: 7 },
+          to: { row: 7, col: 4 }
+        }
+      },
+      {
+        from: { row: 7, col: 3 },
+        to: { row: 7, col: 1 },
+        piece: blackPiece.state,
+        castle: {
+          from: { row: 7, col: 0 },
+          to: { row: 7, col: 2 }
+        }
+      }
+    ];
+
+    const expectedWhiteMoves: Move[] = [
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 0, col: 4 },
+        piece: whitePiece.state
+      },
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 1, col: 4 },
+        piece: whitePiece.state
+      },
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 1, col: 3 },
+        piece: whitePiece.state
+      },
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 1, col: 2 },
+        piece: whitePiece.state
+      },
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 0, col: 2 },
+        piece: whitePiece.state
+      },
+      {
+        from: { row: 0, col: 3 },
+        to: { row: 0, col: 5 },
+        piece: whitePiece.state,
+        castle: {
+          from: { row: 0, col: 6 },
+          to: { row: 0, col: 4 }
+        }
+      }
+    ];
+
+    expect(whiteMoves).toEqual(expectedWhiteMoves);
+  });
 });
 
 describe('eval attacks', () => {

--- a/src/mahaDosGame/Pieces/utils.test.ts
+++ b/src/mahaDosGame/Pieces/utils.test.ts
@@ -5,12 +5,17 @@ import {
   GameConfigurator,
   GameStateInProgress
 } from 'src/gameMechanics/Game/types';
+import { Matrix } from 'src/gameMechanics/util';
 import { MahaGame } from '../MahaGame';
 import { Knight } from './Knight';
 import { Pawn } from './Pawn';
 import { Queen } from './Queen';
 import { mahaPieceRegistry } from './registry';
-import { getAllAdjecentPiecesToPosition, getPieceMoveThisTurn } from './utils';
+import {
+  getAllAdjecentPiecesToPosition,
+  getPieceMoveThisTurn,
+  checkForRookOnDeterminedDirection
+} from './utils';
 
 describe('test getAllAdjecentPiecesToPosition function', () => {
   test('with no pieces', () => {
@@ -367,5 +372,54 @@ describe('test getPieceMovethisTurn function', () => {
 
     const move = getPieceMoveThisTurn(trackedPiece, game);
     expect(move).toBeUndefined();
+  });
+});
+
+describe('test checkForPieceOnDeterminedDirection for both left and right', () => {
+  test('check for Rook on the left of King', () => {
+    const pieceLayout: Matrix<keyof typeof mahaPieceRegistry | 0> = [
+      ['wR', 'wN', 0, 'wK', 0, 0, 'wR', 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0]
+    ];
+    const game = new MahaGame({ pieceLayout, terrain: { width: 8 } });
+
+    const result = checkForRookOnDeterminedDirection(
+      game.board.state.pieceLayoutState,
+      { row: 0, col: 3 },
+      { row: 0, col: 1 },
+      'white'
+    );
+
+    expect(result).toBeDefined();
+
+    expect(result).toEqual({ row: 0, col: 6 });
+  });
+  test('check for Rook on the right of King - fail', () => {
+    const pieceLayout: Matrix<keyof typeof mahaPieceRegistry | 0> = [
+      ['wR', 'wN', 0, 'wK', 0, 0, 'wR', 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0]
+    ];
+    const game = new MahaGame({ pieceLayout, terrain: { width: 8 } });
+
+    const result = checkForRookOnDeterminedDirection(
+      game.board.state.pieceLayoutState,
+      { row: 0, col: 3 },
+      { row: 0, col: -1 },
+      'white'
+    );
+
+    expect(result).toBeUndefined();
   });
 });

--- a/src/mahaDosGame/Pieces/utils.ts
+++ b/src/mahaDosGame/Pieces/utils.ts
@@ -7,13 +7,15 @@ import {
   range,
   matrixInsertMany,
   MatrixIndex,
-  matrixGet
+  matrixGet,
+  Matrix
 } from '../../gameMechanics/util';
 import { coordsAreEqual } from '../../gameMechanics/util/misc';
 import { toDictIndexedBy } from '../../gameMechanics/utils';
 import { PieceLayoutState } from '../../gameMechanics/Board/types';
-import { Move } from '../../gameMechanics/commonTypes';
+import { Color, Move } from '../../gameMechanics/commonTypes';
 import { isGameInMovePhase } from '../../gameMechanics/Game/helpers';
+import { Err, Ok, Result } from 'ts-results';
 
 const determineRange = (moves: Coord[], moveRange: number) => {
   return moves.reduce((totalRange, dir) => {
@@ -192,4 +194,41 @@ export function getPieceMoveThisTurn(
   }
 
   return undefined;
+}
+
+export function checkForRookOnDeterminedDirection(
+  matrix: Matrix<0 | IdentifiablePieceState<string>>,
+  from: Coord,
+  dir: Coord,
+  color: Color
+): Coord | undefined {
+  let skip = false;
+  const check = range(matrix[0].length, 1).reduce((result, nextSquareIndex) => {
+    if (skip) {
+      return result;
+    }
+    const targetSq: Coord = {
+      row: from.row + dir.row * nextSquareIndex,
+      col: from.col + dir.col * nextSquareIndex
+    };
+    if (targetSq.col < matrix[0].length && targetSq.col > -1) {
+      const checkForPiece = matrixGet(matrix, [targetSq.row, targetSq.col]);
+
+      if (checkForPiece) {
+        if (
+          checkForPiece.label === 'Rook' &&
+          checkForPiece.color === color &&
+          !checkForPiece.pieceHasMoved
+        ) {
+          skip = true;
+          return [...result, targetSq];
+        }
+        skip = true;
+        return result;
+      }
+      return result;
+    }
+    return result;
+  }, [] as Coord[]);
+  return check.length === 0 ? undefined : check[0];
 }

--- a/src/mahaDosGame/Pieces/utils.ts
+++ b/src/mahaDosGame/Pieces/utils.ts
@@ -9,6 +9,7 @@ import {
   MatrixIndex,
   matrixGet
 } from '../../gameMechanics/util';
+import { coordsAreEqual } from '../../gameMechanics/util/misc';
 import { toDictIndexedBy } from '../../gameMechanics/utils';
 import { PieceLayoutState } from '../../gameMechanics/Board/types';
 import { Move } from '../../gameMechanics/commonTypes';
@@ -62,6 +63,9 @@ export function evalEachDirectionForMove(
           [move.from.row, move.from.col]
         );
         if (!pieceFromMatrix) {
+          return total;
+        }
+        if (coordsAreEqual(move.to, from) || coordsAreEqual(move.from, from)) {
           return total;
         }
         return [

--- a/src/mahaDosGame/components/Maha/Maha.tsx
+++ b/src/mahaDosGame/components/Maha/Maha.tsx
@@ -8,7 +8,7 @@ import { Coord, noop } from '../../../gameMechanics/util';
 import { MahaGame } from '../../..//mahaDosGame/MahaGame';
 import { MahaChessTerrain, MahaChessTerrainProps } from '../MahaTerrain';
 import { Button } from '../Button';
-import { Color } from '../../../gameMechanics/commonTypes';
+import { Color, ShortMove } from '../../../gameMechanics/commonTypes';
 import {
   isGameInAttackPhase,
   isGameInAttackPhaseWithPreparingSubmission,
@@ -54,7 +54,9 @@ export const Maha: React.FC<MahaProps> = ({
   onEmptySquareTouched = noop
 }) => {
   const localGameRef = useRef(getGameFromState(gameState));
-  const [possibleMoveSquares, setPossibleMoveSquares] = useState<Coord[]>([]);
+  const [possibleMoveSquares, setPossibleMoveSquares] = useState<ShortMove[]>(
+    []
+  );
   const [possibleAttackSquares, setPossibleAttackSquares] = useState<Coord[]>(
     []
   );
@@ -115,7 +117,7 @@ export const Maha: React.FC<MahaProps> = ({
             const dests = piece?.evalMove(getGameFromState(workingGameState));
 
             if (dests) {
-              setPossibleMoveSquares(dests.map((d) => d.to));
+              setPossibleMoveSquares(dests.map((d) => d));
             }
           } else {
             const dests = piece?.evalAttack(localGameRef.current);
@@ -135,14 +137,11 @@ export const Maha: React.FC<MahaProps> = ({
         }}
         onMove={(move) => {
           setPossibleMoveSquares([]);
+          return localGameRef.current.drawMove(move).map((next) => {
+            setPreparingGameState(next.gameState);
 
-          return localGameRef.current
-            .drawMove(move.from, move.to)
-            .map((next) => {
-              setPreparingGameState(next.gameState);
-
-              return next.move;
-            });
+            return next.move;
+          });
         }}
         onAttack={(attack) => {
           setPossibleAttackSquares([]);
@@ -180,7 +179,6 @@ export const Maha: React.FC<MahaProps> = ({
             disabled={!gameState[playingColor].canDraw}
             label={`Submit Attacks`}
             onClick={() => {
-              console.log('press attack');
               if (
                 preparingGameState &&
                 isGameInAttackPhaseWithPreparingSubmission(

--- a/src/mahaDosGame/components/MahaTerrain/MahaTerrain.tsx
+++ b/src/mahaDosGame/components/MahaTerrain/MahaTerrain.tsx
@@ -35,7 +35,7 @@ export type MahaChessTerrainProps = Omit<
   canInteract?: boolean;
   destinationSquares?: Coord[];
 
-  possibleMoveSquares: Coord[];
+  possibleMoveSquares: ShortMove[];
   onMove: (m: ShortMove) => Result<Move, unknown>;
 
   possibleAttackSquares: Coord[];
@@ -117,11 +117,10 @@ export const MahaChessTerrain: React.FC<MahaChessTerrainProps> = ({
 
   const [attackOverlays, setAttackOverlays] = useState<Coord[]>();
 
-  const [touchedPiece, setTouchedPiece] =
-    useState<{
-      coord: Coord;
-      piece: IdentifiablePieceState;
-    }>();
+  const [touchedPiece, setTouchedPiece] = useState<{
+    coord: Coord;
+    piece: IdentifiablePieceState;
+  }>();
 
   useEffect(() => {
     onPieceTouched(touchedPiece);
@@ -138,7 +137,7 @@ export const MahaChessTerrain: React.FC<MahaChessTerrainProps> = ({
           style: possibleAttackSquareStyle
         })),
         ...possibleMoveSquares.map((dest) => ({
-          ...dest,
+          ...{ row: dest.to.row, col: dest.to.col },
           style: possibleMoveSquareStyle
         })),
         ...(touchedPiece
@@ -228,10 +227,14 @@ export const MahaChessTerrain: React.FC<MahaChessTerrainProps> = ({
       }}
       onEmptySquareTouched={(coord) => {
         if (isGameInMovePhase(gameState) && touchedPiece) {
-          onMove({
-            from: touchedPiece.coord,
-            to: coord
-          });
+          const move = possibleMoveSquares.find(
+            (m) =>
+              coordsAreEqual(m.from, touchedPiece.coord) &&
+              coordsAreEqual(m.to, coord)
+          );
+          if (move) {
+            onMove(move);
+          }
         }
 
         setTouchedPiece(undefined);

--- a/src/stories/FreeGame/Game.stories.tsx
+++ b/src/stories/FreeGame/Game.stories.tsx
@@ -199,8 +199,6 @@ export const PlayWithReconciliator = () => {
         label="Prev"
         disabled={!(currentSnapshotIndex > 0)}
         onClick={() => {
-          console.log('prev');
-
           if (currentSnapshotIndex > 0) {
             setCurrentSnapshotIndex((prev) => prev - 1);
           }
@@ -210,7 +208,6 @@ export const PlayWithReconciliator = () => {
         label="Next"
         disabled={!(gameSnapshots.length > currentSnapshotIndex + 1)}
         onClick={() => {
-          console.log('next');
           if (gameSnapshots.length > currentSnapshotIndex + 1) {
             setCurrentSnapshotIndex((prev) => prev + 1);
           }


### PR DESCRIPTION
 Once another move or attack has been selected it will cancel everything that was added after that piece's previous action.

Implement check to not allow pieces to display possible moves where some other piece just moved in it's place since it will conflict.